### PR TITLE
mailto: must be in the list of protocols

### DIFF
--- a/mkdocs_ezlinks_plugin/scanners/md_link_scanner.py
+++ b/mkdocs_ezlinks_plugin/scanners/md_link_scanner.py
@@ -30,7 +30,7 @@ class MdLinkScanner(BaseLinkScanner):
             )
             \(
                 (?P<md_target>
-                    (?!(?P<md_protocol>[a-z][a-z0-9+\-.]*:\/\/))
+                    (?!(?P<md_protocol>(?:([a-z][a-z0-9+\-.]*:\/\/)|(mailto:))))
                     (?P<md_filename>\/?[^\#\ \)]*)?
                     (?:\#(?P<md_anchor>[^\)\"]*)?)?
                     (?:\ \"(?P<md_title>[^\"\)]*)\")?


### PR DESCRIPTION
This is the another attempt to fix the issue https://github.com/orbikm/mkdocs-ezlinks-plugin/issues/48 **"()[mailto:*] must be treated as a protocol to avoid link conversion"**

The fix allows `[email(a)a.com](mailto:email@a.com)` to be treated as one of the protocols and not apply the conversion to this link type.

PS This is the copy of PR https://github.com/orbikm/mkdocs-ezlinks-plugin/pull/50